### PR TITLE
Allow react@v15 in peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,8 @@
   },
   "homepage": "https://github.com/nkbt/react-height",
   "peerDependencies": {
-    "react": "^0.14"
-  },
-  "dependencies": {
-    "react-addons-pure-render-mixin": "^0.14.0"
+    "react": "^0.14.8 || ^15.0.0",
+    "react-addons-pure-render-mixin": "^0.14.8 || ^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "minicat": "^1.0.0",
     "parallelshell": "^2.0.0",
     "react": "^0.14.7",
+    "react-addons-pure-render-mixin": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.2",


### PR DESCRIPTION
react-addons-pure-render-mixin has been moved to peer dependency because react-addons-pure-render-mixin v0.14 will have peer dependency on react 0.14. Any project that is using react v15 will see peer dependency error if react-addons-shallow-compare is present under dependencies.
