### PR TITLE
Replace import of shouldComponentUpdate with shallowCompare

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "homepage": "https://github.com/nkbt/react-height",
   "peerDependencies": {
-    "react": "^0.14 || ^15"
+    "react": "^0.14 || ^15",
+    "react-addons-shallow-compare": "^0.14 || ^15"
   },
   "devDependencies": {
     "babel-cli": "6.10.1",
@@ -67,6 +68,7 @@
     "parallelshell": "2.0.0",
     "react-dom": "15.2.0",
     "react": "15.2.0",
+    "react-addons-shallow-compare": "15.2.0",
     "rimraf": "2.5.3",
     "sinon": "1.17.4",
     "style-loader": "0.13.1",

--- a/src/ReactHeight.js
+++ b/src/ReactHeight.js
@@ -3,7 +3,7 @@
 
 
 import React from 'react';
-import {shallowCompare} from 'react-addons-shallow-compare';
+import shallowCompare from 'react-addons-shallow-compare';
 
 
 const ReactHeight = React.createClass({

--- a/src/ReactHeight.js
+++ b/src/ReactHeight.js
@@ -3,7 +3,7 @@
 
 
 import React from 'react';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
+import {shallowCompare} from 'react-addons-shallow-compare';
 
 
 const ReactHeight = React.createClass({
@@ -42,7 +42,9 @@ const ReactHeight = React.createClass({
   },
 
 
-  shouldComponentUpdate,
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  },
 
 
   componentDidUpdate() {


### PR DESCRIPTION
The current code imports `shouldComponentUpdate` directly from the bowels of React; this trips over Preact compatibility. This change loads `shallowCompare` in the documented way, which allows Preact magic to be applied.
