### PR TITLE
Migrated deprecated React.PropTypes and React.createClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,9 @@
     "tape": "4.6.3",
     "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2"
+  },
+  "dependencies": {
+    "create-react-class": "15.5.2",
+    "prop-types": "15.5.8"
   }
 }

--- a/src/ReactHeight.js
+++ b/src/ReactHeight.js
@@ -3,17 +3,19 @@
 
 
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 
 const getElementHeight = el => el.clientHeight;
 
-const ReactHeight = React.createClass({
+const ReactHeight = createReactClass({
   propTypes: {
-    children: React.PropTypes.node.isRequired,
-    onHeightReady: React.PropTypes.func.isRequired,
-    hidden: React.PropTypes.bool,
-    dirty: React.PropTypes.bool,
-    getElementHeight: React.PropTypes.func
+    children: PropTypes.node.isRequired,
+    onHeightReady: PropTypes.func.isRequired,
+    hidden: PropTypes.bool,
+    dirty: PropTypes.bool,
+    getElementHeight: PropTypes.func
   },
 
 

--- a/src/example/App/Nested.js
+++ b/src/example/App/Nested.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import ReactHeight from '../../ReactHeight';
 import VariableText from './VariableText';
 import css from './App.css';
 
 
-const Nested = React.createClass({
+const Nested = createReactClass({
   getInitialState() {
     return {blocks: 1, height: -1, dirty: true};
   },

--- a/src/example/App/VariableText.js
+++ b/src/example/App/VariableText.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import ReactHeight from '../../ReactHeight';
 import text from './../text.json';
@@ -8,7 +9,7 @@ import css from './App.css';
 const getText = num => text.slice(0, num).map((p, i) => <p key={i}>{p}</p>);
 
 
-const VariableText = React.createClass({
+const VariableText = createReactClass({
   getInitialState() {
     return {paragraphs: 0, height: -1};
   },

--- a/src/example/App/index.js
+++ b/src/example/App/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import VariableText from './VariableText';
 import Nested from './Nested';
 import {name} from '../../../package.json';
 import css from './App.css';
 
 
-const App = React.createClass({
+const App = createReactClass({
   render() {
     return (
       <div className={css.container}>


### PR DESCRIPTION
I think we should migrate to the es6 `class` syntax and stop using `React.createClass`, but that would be another step. For now just created this PR, so people stop having deprecation warnings after migration to React v15.5. 

If you feel the same about `class`, I'll create an issue about it, so the matter won't get forgotten and neglected.