### PR TITLE
Update prop-types to 15.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "webpack-dev-server": "2.4.2"
   },
   "dependencies": {
-    "prop-types": "15.5.8"
+    "prop-types": "15.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "webpack-dev-server": "2.4.2"
   },
   "dependencies": {
-    "prop-types": "15.5.10"
+    "prop-types": "^15.5.8"
   }
 }


### PR DESCRIPTION
Hello. 

Using your library we have a warning "Calling PropTypes validators directly is not supported by the `prop-types`"

This question has already been discussed here: https://github.com/malte-wessel/react-custom-scrollbars/issues/153 and people advice to update prop-types to 15.5.10

Thank you.